### PR TITLE
contrib: Update zig build system for 0.11.0-dev.2725+4374ce51b

### DIFF
--- a/perfaware/sim86/shared/contrib_zig/README.md
+++ b/perfaware/sim86/shared/contrib_zig/README.md
@@ -9,7 +9,7 @@ to build the C++ shared library and then interface with it via the
 
 ## Building and running
 
-Tested Zig Version: `0.11.0-dev.1987+a2c6ecd6d`
+Tested Zig Version: `0.11.0-dev.2725+4374ce51b`
 
 To run the test file:
 

--- a/perfaware/sim86/shared/contrib_zig/build.zig
+++ b/perfaware/sim86/shared/contrib_zig/build.zig
@@ -41,7 +41,7 @@ pub fn build(b: *std.Build) void {
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
     // running `zig build`).
-    lib.install();
+    b.installArtifact(lib);
 
     // Creates a step for unit testing.
     const main_tests = b.addTest(.{
@@ -51,9 +51,11 @@ pub fn build(b: *std.Build) void {
     });
     main_tests.linkLibrary(lib);
 
+    const run_main_tests = b.addRunArtifact(main_tests);
+
     // This creates a build step. It will be visible in the `zig build --help` menu,
     // and can be selected like this: `zig build test`
     // This will evaluate the `test` step rather than the default, which is "install".
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+    test_step.dependOn(&run_main_tests.step);
 }


### PR DESCRIPTION
@penguingovernor thanks for providing the zig wrappers, this PR updates `build.zig` for the latest changes in the build system, tested w/ `0.11.0-dev.2725+4374ce51b`.

In summary, installation was moved to the top `std.Build` instead of via methods on the individual steps, see https://github.com/ziglang/zig/issues/15079 for more details.

Likewise the process for connecting the run step changed and requires calling `b.addRunArtifact`, see the commit message on https://github.com/ziglang/zig/commit/dad6039092d02460d5e993855b129da9949e9c5c for more details.

Both changes were found by running `zig init-lib` in an empty directory and comparing the newly generated `build.zig` with yours. 

