### PR TITLE
Zig Reference Decoder Wrapper: Fixes for Latest Zig Release (0.11)

### DIFF
--- a/perfaware/sim86/shared/contrib_zig/README.md
+++ b/perfaware/sim86/shared/contrib_zig/README.md
@@ -9,7 +9,7 @@ to build the C++ shared library and then interface with it via the
 
 ## Building and running
 
-Tested Zig Version: `0.11.0-dev.2725+4374ce51b`
+Tested Zig Version: `0.11.0`
 
 To run the test file:
 

--- a/perfaware/sim86/shared/contrib_zig/build.zig
+++ b/perfaware/sim86/shared/contrib_zig/build.zig
@@ -33,8 +33,8 @@ pub fn build(b: *std.Build) void {
     // In "production" Zig, you wouldn't use relatives paths. You'd add the
     // sim86 library files to a `vendor` or `third_party` directory and source
     // from there.
-    lib.addIncludePath("..");
-    lib.addCSourceFile("../../sim86_lib.cpp", &.{});
+    lib.addIncludePath(.{ .path = ".." });
+    lib.addCSourceFile(.{ .file = .{ .path = "../../sim86_lib.cpp" }, .flags = &[_][]const u8{} });
     lib.linkLibCpp();
     lib.installHeader("../sim86_shared.h", "sim86_shared.h");
 

--- a/perfaware/sim86/shared/contrib_zig/src/sim86.zig
+++ b/perfaware/sim86/shared/contrib_zig/src/sim86.zig
@@ -265,7 +265,7 @@ pub fn get8086InstructionTable() InstructionTable {
 
 pub fn decode8086Instruction(source: []u8) !Instruction {
     var decoded: Instruction = undefined;
-    Sim86_Decode8086Instruction(@intCast(c_uint, source.len), source.ptr, &decoded);
+    Sim86_Decode8086Instruction(@as(c_uint, @intCast(source.len)), source.ptr, &decoded);
     if (decoded.Op == OperationType.Op_None) {
         return DecodeError.UnrecognizedInstruction;
     }

--- a/perfaware/sim86/shared/contrib_zig/src/sim86_test.zig
+++ b/perfaware/sim86/shared/contrib_zig/src/sim86_test.zig
@@ -258,12 +258,12 @@ fn makeExampleDisassemblyCopy(allocator: std.mem.Allocator) ![]u8 {
 }
 
 test "sim86GetVersion" {
-    try std.testing.expectEqual(sim86.getVersion(), 3);
+    try std.testing.expectEqual(sim86.getVersion(), 4);
 }
 
 test "get8086InstructionTable" {
     const table = sim86.get8086InstructionTable();
-    try std.testing.expectEqual(@intCast(u32, 133), table.EncodingCount);
+    try std.testing.expectEqual(@as(u32, @intCast(133)), table.EncodingCount);
 }
 
 test "decode8086Instruction/mnemonicFromOperationType" {
@@ -273,7 +273,7 @@ test "decode8086Instruction/mnemonicFromOperationType" {
     defer allocator.free(mem);
 
     var decoded = try sim86.decode8086Instruction(mem);
-    try std.testing.expectEqual(@intCast(u32, 2), decoded.Size);
+    try std.testing.expectEqual(@as(u32, 2), decoded.Size);
     try std.testing.expectEqual(sim86.InstructionFlag{ .Wide = true }, decoded.Flags);
     try std.testing.expectEqualStrings("add", sim86.mnemonicFromOperationType(decoded.Op));
     try std.testing.expectEqual(sim86.OperandType.OperandRegister, decoded.Operands[0].Type);


### PR DESCRIPTION
Hi Casey,

I've joined the course late and so far I've been participating in Zig. I also want to use the reference decoder, although I did do most of the homework in Zig. I've made some minimal changes to get the Zig wrapper to build (and the tests to pass) with Zig 0.11, which is the latest released version (not the latest nightly version).

I'd appreciate it if you merged the changes. Should you happen to have Zig installed on your system you can verify that the tests pass using `zig build test` in the `contrib_zig` directory. Or you can trust me, some guy on the internet.