### PR TITLE
Improve error messages.

### DIFF
--- a/perfaware/part4/listing_0172_reference_haversine.cpp
+++ b/perfaware/part4/listing_0172_reference_haversine.cpp
@@ -38,7 +38,7 @@ struct haversine_setup
     haversine_pair *Pairs;
     f64 *Answers;
     
-    f64 SumAnswer;
+    f64 AverageAnswer;
     
     b32 Valid;
 };
@@ -166,7 +166,7 @@ static haversine_setup SetUpHaversine(char *PairsJSONFileName, char *AnswerFileN
         {
             Result.PairCount = PairCount;
             Result.Answers = (f64 *)Result.AnswerBuffer.Data;
-            Result.SumAnswer = Result.Answers[PairCount];
+            Result.AverageAnswer = Result.Answers[PairCount];
             
             Result.ParsedByteCount = (sizeof(haversine_pair)*Result.PairCount);
             
@@ -174,6 +174,11 @@ static haversine_setup SetUpHaversine(char *PairsJSONFileName, char *AnswerFileN
             fprintf(stdout, "Source JSON: %llumb\n", Result.JSONBuffer.Count/Megabyte);
             fprintf(stdout, "Parsed: %llumb (%llu pairs)\n", Result.ParsedByteCount/Megabyte, Result.PairCount);
             
+            if (Result.PairCount == 0)
+            {
+                fprintf(stderr, "ERROR: Test data is empty.\n");
+            }
+
             Result.Valid = (Result.PairCount != 0);
         }
         else

--- a/perfaware/part4/listing_0173_reference_haversine_main.cpp
+++ b/perfaware/part4/listing_0173_reference_haversine_main.cpp
@@ -68,7 +68,7 @@ int main(int ArgCount, char **Args)
         repetition_test_series TestSeries = AllocateTestSeries(ArrayCount(TestFunctions), 1);
         if(IsValid(Setup) && IsValid(TestSeries))
         {
-            f64 ReferenceSum = Setup.SumAnswer;
+            f64 AverageAnswer = Setup.AverageAnswer;
             
             SetRowLabelLabel(&TestSeries, "Test");
             SetRowLabel(&TestSeries, "Haversine");
@@ -82,7 +82,8 @@ int main(int ArgCount, char **Args)
                 NewTestWave(&TestSeries, &Tester, Setup.ParsedByteCount, GetCPUTimerFreq());
                 
                 u64 IndividualErrorCount = Function.Verify(Setup);
-                u64 SumErrorCount = {};
+                u64 AverageErrorCount = {};
+                u64 Iterations = 0;
                 
                 while(IsTesting(&TestSeries, &Tester))
                 {
@@ -91,13 +92,13 @@ int main(int ArgCount, char **Args)
                     CountBytes(&Tester, Setup.ParsedByteCount);
                     EndTime(&Tester);
 
-                    SumErrorCount += !ApproxAreEqual(Check, ReferenceSum);
+                    AverageErrorCount += !ApproxAreEqual(Check, AverageAnswer);
                 }
                 
-                if(SumErrorCount || IndividualErrorCount)
+                if(AverageErrorCount || IndividualErrorCount)
                 {
-                    fprintf(stderr, "WARNING: %llu haversines mismatched, %llu sum mismatches\n",
-                            IndividualErrorCount, SumErrorCount);
+                    fprintf(stderr, "WARNING: %llu haversines mismatched, %llu averages mismatched (%llu iterations)\n",
+                            IndividualErrorCount, AverageErrorCount, Iterations);
                 }
             }
             
@@ -105,7 +106,7 @@ int main(int ArgCount, char **Args)
         }
         else
         {
-            fprintf(stderr, "ERROR: Test data size must be non-zero\n");
+            fprintf(stderr, "ERROR: Test data invalid.\n");
         }
         
         FreeHaversine(&Setup);
@@ -113,7 +114,10 @@ int main(int ArgCount, char **Args)
     }
     else
     {
-        fprintf(stderr, "Usage: %s [existing filename]\n", Args[0]);
+        fprintf(stderr, "Usage: %s PAIRS ANSWERS\n"
+          "where PAIRS is an existing JSON file with N coordinate pairs\n"
+          "and ANSWERS is an existing binary answers file with N haversine distances\n"
+          "followed by the average distance (8-byte floats).\n", Args[0]);
     }
 		
     return 0;


### PR DESCRIPTION
- Usage message now explains both args, and does not use square brackets for non-optional args.
- Only say that the test data is empty if it actually is. (My answers file was the wrong size, and that triggered the misleading "Test data size must be non-zero." error.)
- Use the word "Average" instead of "Sum" in most places to describe the number computed by adding the distances together and dividing by the number of them.